### PR TITLE
kafka Innmemory implementation

### DIFF
--- a/KafkaInMemory/consumer.go
+++ b/KafkaInMemory/consumer.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+type Consumer struct {
+	Id     string
+	Topics map[string]*ConsumerMetadata
+}
+
+type ConsumerMetadata struct {
+	lastReadIndex int
+	maxSize       int // Can be configured here, or at common consumer layer
+}
+
+func NewConsumer(id string) *Consumer {
+	return &Consumer{
+		Id:     id,
+		Topics: map[string]*ConsumerMetadata{},
+	}
+}
+
+func (c *Consumer) RegisterToTopic(topicName string, maxSizeOfRead int) {
+	c.Topics[topicName] = &ConsumerMetadata{lastReadIndex: 0, maxSize: maxSizeOfRead}
+}
+
+func (c *Consumer) Runnable(k *KafkaQueue) {
+	// Every 2 secs, check for 3 messages in the kafka queue
+	for {
+		time.Sleep(2 * time.Second)
+		for name, data := range c.Topics {
+			messages := k.ReadFromIndex(name, data.lastReadIndex+1, data.maxSize)
+			c.ProcessMessage(messages)
+			data.lastReadIndex += len(messages)
+		}
+	}
+}
+
+func (c *Consumer) ProcessMessage(messages []*Message) {
+	for i := 0; i < len(messages); i++ {
+		fmt.Println(fmt.Sprintf("%v:%v", c.Id, messages[i].Content))
+	}
+}

--- a/KafkaInMemory/go.mod
+++ b/KafkaInMemory/go.mod
@@ -1,0 +1,3 @@
+module github.com/cipherkee/SystemDesign/KafkaInMemory
+
+go 1.23.2

--- a/KafkaInMemory/main.go
+++ b/KafkaInMemory/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+/*
+The queue should be in-memory and should not require access to the file system.
+There can be multiple topics in the queue.
+A (string) message can be published on a topic by a producer/publisher and consumers/subscribers can subscribe to the topic to receive the messages.
+There can be multiple producers and consumers.
+A producer can publish to multiple topics.
+A consumer can listen to multiple topics.
+The consumer should print "<consumer_id> received <message>" on receiving the message.
+The queue system should be multi-threaded, i.e., messages can be produced or consumed in parallel by different producers/consumers.
+*/
+
+func main() {
+
+	var (
+		topic1 = "topic1"
+		wg     sync.WaitGroup
+	)
+
+	k := NewKafkaQueue()
+	// 1 topic
+	k.RegisterATopic(topic1)
+
+	// 2 publishers
+	p1 := NewPublisher("p1")
+	p2 := NewPublisher("p2")
+
+	// 2 consumers
+	c1 := NewConsumer("c1")
+	c2 := NewConsumer("c2")
+
+	c1.RegisterToTopic(topic1, 3)
+	c2.RegisterToTopic(topic1, 3)
+	go func() {
+		wg.Add(1)
+		c1.Runnable(k)
+	}()
+	go func() {
+		wg.Add(1)
+		c2.Runnable(k)
+	}()
+
+	time.Sleep(2 * time.Second)
+	go func() {
+		wg.Add(1)
+		publishMessageEveryTSec(k, p1, topic1, 5)
+	}()
+	go func() {
+		wg.Add(1)
+		publishMessageEveryTSec(k, p2, topic1, 5)
+	}()
+
+	wg.Wait()
+}
+
+func publishMessageEveryTSec(k *KafkaQueue, p *Publisher, topic string, t int) {
+	count := 0
+	for {
+		time.Sleep(time.Duration(t) * time.Second)
+		p.PushToKafkaTopic(k, topic, fmt.Sprintf("message:%v:%vs::%v", p.Id, t, count))
+		count += t
+	}
+}

--- a/KafkaInMemory/publisher.go
+++ b/KafkaInMemory/publisher.go
@@ -1,0 +1,15 @@
+package main
+
+type Publisher struct {
+	Id string
+}
+
+func NewPublisher(Id string) *Publisher {
+	return &Publisher{
+		Id: Id,
+	}
+}
+
+func (p *Publisher) PushToKafkaTopic(k *KafkaQueue, topic, msg string) {
+	k.PublishMessage(topic, msg)
+}

--- a/KafkaInMemory/queue.go
+++ b/KafkaInMemory/queue.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"sync"
+)
+
+type KafkaQueue struct {
+	msg map[string][]*Message
+
+	mu sync.RWMutex
+	// TODO: Register publisher, consumer and validate if correct pub, consumer are read from a topic
+	// TODO: Locking if needed
+}
+
+func NewKafkaQueue() *KafkaQueue {
+	return &KafkaQueue{
+		msg: map[string][]*Message{},
+	}
+}
+
+type Message struct {
+	Content string
+}
+
+func NewKafkaMessage(msg string) *Message {
+	return &Message{Content: msg}
+}
+
+func (k *KafkaQueue) RegisterATopic(topic string) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.msg[topic] = make([]*Message, 0)
+}
+
+func (k *KafkaQueue) PublishMessage(topic, msg string) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.msg[topic] = append(k.msg[topic], NewKafkaMessage(msg))
+}
+
+func (k *KafkaQueue) ReadFromIndex(topic string, index int, maxSize int) []*Message {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	messages, ok := k.msg[topic]
+	if !ok {
+		return nil
+	}
+	if index < len(messages) {
+		return messages[index:min(index+maxSize, len(messages))]
+	}
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
**kafka Innmemory implementation**
1. Create Topics
2. Create Publishers, subscribe to multiple topics
3. Create Subscribers, subscribe to multiple topics
4. Concurrently running consumers listening to topics
5. Concurrently running publishers publishing messages to topics
6. Locking mechanism in Kakfa

TODO: 
1. Validate consumers and publishers listening to topics

